### PR TITLE
Make pings async-safe and bounded

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,7 +47,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -58,7 +58,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -143,7 +143,7 @@ dependencies = [
  "libc",
  "once_cell",
  "unicode-width",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -215,6 +215,17 @@ name = "log"
 version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
+
+[[package]]
+name = "mio"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69d83b0086dc8ecf3ce9ae2874b2d1290252e2a30720bea58a5c6639b0092873"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "num-traits"
@@ -303,6 +314,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "socket2"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17129e116933cf371d018bb80ae557e889637989d8638274fb25622827b03881"
+dependencies = [
+ "libc",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -336,8 +366,13 @@ version = "1.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff360e02eab121e0bc37a2d3b4d4dc622e6eda3a8e5253d5435ecf5bd4c68408"
 dependencies = [
+ "libc",
+ "mio",
  "pin-project-lite",
+ "signal-hook-registry",
+ "socket2",
  "tokio-macros",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -377,6 +412,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasm-bindgen"
@@ -484,12 +525,86 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winres"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,8 @@ build = "src/build.rs"
 chrono = { version = "0.4.42", default-features = false, features = ["clock"] }
 clap = "4.5.53"
 console = "0.16.1"
-tokio = { version = "1.48.0", features = ["macros", "rt-multi-thread", "time"] }
+tokio = { version = "1.48.0", features = ["macros", "rt-multi-thread", "time", "net", "signal"] }
+
 
 [target.'cfg(target_os="windows")'.build-dependencies]
 winres = "0.1.12"

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,9 +3,9 @@ use clap::{Arg, Command};
 use console::style;
 use std::error::Error;
 use std::io::{self, Error as IOError, Write};
-use std::net::{SocketAddr, TcpStream, ToSocketAddrs};
+use std::net::{SocketAddr, ToSocketAddrs};
 use std::time::{Duration, Instant};
-use tokio::time;
+use tokio::{net::TcpStream, signal, time};
 
 const DEFAULT_TIMEOUT_MS: u64 = 4_000;
 
@@ -74,25 +74,42 @@ async fn main_impl() -> Result<(), Box<dyn Error>> {
     let addr = resolve_target(target)?;
 
     // Warmup.
-    print_timed_ping(&addr, DEFAULT_TIMEOUT_MS, true, continuous);
+    print_timed_ping(&addr, DEFAULT_TIMEOUT_MS, true, continuous).await;
 
     // Actual timed ping.
-    let mut results = Vec::new();
+    let mut stats = PingStats::new();
 
-    while continuous || (results.len() as u64) < count {
-        time::sleep(Duration::from_millis(interval_ms)).await;
-        results.push(print_timed_ping(
-            &addr,
-            DEFAULT_TIMEOUT_MS,
-            false,
-            continuous,
-        ));
+    if continuous {
+        let ctrl_c = signal::ctrl_c();
+        tokio::pin!(ctrl_c);
+        loop {
+            tokio::select! {
+                _ = &mut ctrl_c => {
+                    break;
+                }
+                _ = time::sleep(Duration::from_millis(interval_ms)) => {
+                    let result = print_timed_ping(
+                        &addr,
+                        DEFAULT_TIMEOUT_MS,
+                        false,
+                        continuous,
+                    ).await;
+                    stats.record(result);
+                }
+            }
+        }
+    } else {
+        for _ in 0..count {
+            time::sleep(Duration::from_millis(interval_ms)).await;
+            let result = print_timed_ping(&addr, DEFAULT_TIMEOUT_MS, false, continuous).await;
+            stats.record(result);
+        }
     }
 
-    if !results.is_empty() {
+    if stats.sent > 0 {
         // Print stats (psping format):
         println!();
-        print_stats(&results);
+        print_stats(&stats);
     }
 
     Ok(())
@@ -122,7 +139,12 @@ fn resolve_target(target: &str) -> Result<SocketAddr, IOError> {
     }
 }
 
-fn print_timed_ping(addr: &SocketAddr, timeout_ms: u64, warmup: bool, time: bool) -> Option<f64> {
+async fn print_timed_ping(
+    addr: &SocketAddr,
+    timeout_ms: u64,
+    warmup: bool,
+    time: bool,
+) -> Option<f64> {
     if warmup {
         if time {
             let now = Local::now().format("%H:%M:%S");
@@ -139,7 +161,7 @@ fn print_timed_ping(addr: &SocketAddr, timeout_ms: u64, warmup: bool, time: bool
         print!("> {}: ", addr);
     }
 
-    match timed_ping(addr, timeout_ms) {
+    match timed_ping(addr, timeout_ms).await {
         Err(err) => {
             println!("{}", style(&err).cyan());
             None
@@ -151,18 +173,60 @@ fn print_timed_ping(addr: &SocketAddr, timeout_ms: u64, warmup: bool, time: bool
     }
 }
 
-fn timed_ping(addr: &SocketAddr, timeout_ms: u64) -> Result<f64, IOError> {
+async fn timed_ping(addr: &SocketAddr, timeout_ms: u64) -> Result<f64, IOError> {
     let start = Instant::now();
 
-    TcpStream::connect_timeout(addr, Duration::from_millis(timeout_ms))?;
-
-    Ok(start.elapsed().as_secs_f64() * 1000.0)
+    let connect = TcpStream::connect(addr);
+    match time::timeout(Duration::from_millis(timeout_ms), connect).await {
+        Ok(Ok(_stream)) => Ok(start.elapsed().as_secs_f64() * 1000.0),
+        Ok(Err(err)) => Err(err),
+        Err(_) => Err(IOError::new(
+            io::ErrorKind::TimedOut,
+            "connection timed out",
+        )),
+    }
 }
 
-fn print_stats(results: &[Option<f64>]) {
-    let successes: Vec<f64> = results.iter().copied().flatten().collect();
+struct PingStats {
+    sent: usize,
+    received: usize,
+    min: Option<f64>,
+    max: Option<f64>,
+    sum: f64,
+}
 
-    let success_percent = successes.len() * 100 / results.len();
+impl PingStats {
+    fn new() -> Self {
+        Self {
+            sent: 0,
+            received: 0,
+            min: None,
+            max: None,
+            sum: 0.0,
+        }
+    }
+
+    fn record(&mut self, result: Option<f64>) {
+        self.sent += 1;
+        if let Some(latency) = result {
+            self.received += 1;
+            self.sum += latency;
+            self.min = Some(self.min.map_or(latency, |min| min.min(latency)));
+            self.max = Some(self.max.map_or(latency, |max| max.max(latency)));
+        }
+    }
+
+    fn avg(&self) -> Option<f64> {
+        if self.received == 0 {
+            None
+        } else {
+            Some(self.sum / self.received as f64)
+        }
+    }
+}
+
+fn print_stats(stats: &PingStats) {
+    let success_percent = stats.received * 100 / stats.sent;
 
     let formatted_percent = {
         match success_percent {
@@ -186,24 +250,10 @@ fn print_stats(results: &[Option<f64>]) {
 
     println!(
         "  Sent = {}, Received = {} ({})",
-        results.len(),
-        successes.len(),
-        formatted_percent
+        stats.sent, stats.received, formatted_percent
     );
 
-    if !successes.is_empty() {
-        let min = successes
-            .iter()
-            .min_by(|&x, &y| x.partial_cmp(y).unwrap())
-            .unwrap();
-
-        let max = successes
-            .iter()
-            .max_by(|&x, &y| x.partial_cmp(y).unwrap())
-            .unwrap();
-
-        let avg = successes.iter().sum::<f64>() / successes.len() as f64;
-
+    if let (Some(min), Some(max), Some(avg)) = (stats.min, stats.max, stats.avg()) {
         println!(
             "  Minimum = {:.2}ms, Maximum = {:.2}ms, Average = {:.2}ms",
             min, max, avg
@@ -246,23 +296,23 @@ mod tests {
     use std::io;
     use std::net::TcpListener;
 
-    #[test]
-    fn test_timed_ping_success() {
+    #[tokio::test]
+    async fn test_timed_ping_success() {
         let listener = TcpListener::bind("127.0.0.1:0").unwrap();
         let addr = listener.local_addr().unwrap();
 
-        let result = timed_ping(&addr, DEFAULT_TIMEOUT_MS);
+        let result = timed_ping(&addr, DEFAULT_TIMEOUT_MS).await;
         assert!(result.is_ok());
     }
 
-    #[test]
-    fn test_timed_ping_timeout() {
+    #[tokio::test]
+    async fn test_timed_ping_timeout() {
         // Find an unused port.
         let listener = TcpListener::bind("127.0.0.1:0").unwrap();
         let addr = listener.local_addr().unwrap();
         drop(listener);
 
-        let result = timed_ping(&addr, 1);
+        let result = timed_ping(&addr, 1).await;
         assert!(result.is_err());
     }
 
@@ -297,9 +347,12 @@ mod tests {
 
     #[test]
     fn test_print_stats() {
-        let results = vec![Some(10.0), Some(20.0), Some(30.0), None];
+        let mut stats = PingStats::new();
+        for result in [Some(10.0), Some(20.0), Some(30.0), None] {
+            stats.record(result);
+        }
         // This test will just execute the function to ensure it doesn't panic.
         // We can't easily assert the output without capturing stdout.
-        print_stats(&results);
+        print_stats(&stats);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -82,18 +82,23 @@ async fn main_impl() -> Result<(), Box<dyn Error>> {
     if continuous {
         let ctrl_c = signal::ctrl_c();
         tokio::pin!(ctrl_c);
-        loop {
+        'ping_loop: loop {
             tokio::select! {
                 _ = &mut ctrl_c => {
-                    break;
+                    break 'ping_loop;
                 }
                 _ = time::sleep(Duration::from_millis(interval_ms)) => {
-                    let result = print_timed_ping(
-                        &addr,
-                        DEFAULT_TIMEOUT_MS,
-                        false,
-                        continuous,
-                    ).await;
+                    let result = tokio::select! {
+                        _ = &mut ctrl_c => {
+                            break 'ping_loop;
+                        }
+                        result = print_timed_ping(
+                            &addr,
+                            DEFAULT_TIMEOUT_MS,
+                            false,
+                            continuous,
+                        ) => result,
+                    };
                     stats.record(result);
                 }
             }


### PR DESCRIPTION
## Summary
- switch to non-blocking TCP connect with timeout using Tokio
- handle Ctrl+C in continuous mode and still emit stats
- replace per-ping storage with rolling stats for bounded memory